### PR TITLE
Use ES module import rather than createRequire

### DIFF
--- a/gen-esm-wrapper.js
+++ b/gen-esm-wrapper.js
@@ -27,10 +27,7 @@ let relPath = relative(target === '-' ? './' : dirname(target), source)
 if (!relPath.startsWith('./') && !relPath.startsWith('../') && relPath != '..')
   relPath = `./${relPath}`;
 
-let output = `import { createRequire } from 'module';
-const mod = createRequire(import.meta.url)(${JSON.stringify(relPath)});
-
-`;
+let output = `import mod from './${relPath}';`
 
 if (!keys.has('default')) {
   output += 'export default mod;\n';

--- a/gen-esm-wrapper.js
+++ b/gen-esm-wrapper.js
@@ -27,7 +27,9 @@ let relPath = relative(target === '-' ? './' : dirname(target), source)
 if (!relPath.startsWith('./') && !relPath.startsWith('../') && relPath != '..')
   relPath = `./${relPath}`;
 
-let output = `import mod from './${relPath}';`
+let output = `import mod from './${relPath}';
+
+`
 
 if (!keys.has('default')) {
   output += 'export default mod;\n';


### PR DESCRIPTION
`createRequire` is not supported by bundlers so will break usage for Rollup / Webpack / Parcel / ncc / node-file-trace.

Just importing should be fine if it is a CommonJS module anyway exposed by exports since that means `require()` has to work (would error otherwise).