### PR TITLE
test: add test when no target

### DIFF
--- a/gen-esm-wrapper.js
+++ b/gen-esm-wrapper.js
@@ -7,7 +7,7 @@ const fs = require('fs');
 const source = process.argv[2];
 const target = process.argv[3] || '-';
 
-if (typeof source !== 'string' || typeof target !== 'string') {
+if (typeof source !== 'string') {
   console.error('Usage: esm-wrapper-gen <path-to-module> <path-to-output>');
   return;
 }

--- a/test/test.js
+++ b/test/test.js
@@ -6,6 +6,20 @@ const { execFileSync } = require('child_process');
 
 const updateSnapshots = process.argv[2] === 'update-snapshots';
 
+const getOutputWithoutTarget = dir => {
+  const entrydir = resolve(__dirname, 'fixtures', dir, 'out');
+  const origcwd = process.cwd();
+
+  process.chdir(entrydir);
+  const stdoutWithoutTarget = execFileSync(process.execPath, [
+    resolve(__dirname, '../gen-esm-wrapper.js'),
+    resolve(__dirname, `fixtures/${dir}/index.js`)
+  ]);
+  process.chdir(origcwd);
+
+  return stdoutWithoutTarget;
+}
+
 for (const dir of fs.readdirSync(resolve(__dirname, 'fixtures'))) {
   console.log(`Testing in directory ${dir}`);
   execFileSync(process.execPath, [
@@ -13,6 +27,9 @@ for (const dir of fs.readdirSync(resolve(__dirname, 'fixtures'))) {
     resolve(__dirname, `fixtures/${dir}/index.js`),
     resolve(__dirname, `fixtures/${dir}/out/wrapper.mjs`)
   ]);
+
+  // trim the last '\n'
+  const outputWithoutTarget = getOutputWithoutTarget(dir).slice(0, -1);
 
   const actual = fs.readFileSync(
     resolve(__dirname, `fixtures/${dir}/out/wrapper.mjs`), 'utf8');
@@ -23,5 +40,6 @@ for (const dir of fs.readdirSync(resolve(__dirname, 'fixtures'))) {
     const expected = fs.readFileSync(
       resolve(__dirname, `fixtures/${dir}/wrapper.mjs`), 'utf8');
     assert.strictEqual(actual, expected);
+    assert.strictEqual(Buffer.from(expected).equals(outputWithoutTarget), true);
   }
 }


### PR DESCRIPTION
When no target provided, target would be `'-'`, always be type of string.

And add test when no target provided.