### PR TITLE
Generate exports in consistent (ascending sorted) order

### DIFF
--- a/gen-esm-wrapper.js
+++ b/gen-esm-wrapper.js
@@ -61,7 +61,7 @@ let output = `import mod from ${JSON.stringify(relPath)};
 `;
 
 output += 'export default mod;\n';
-for (const key of keys) {
+for (const key of [...keys].sort()) {
   if (isValidIdentifier(key)) {
     output += `export const ${key} = mod.${key};\n`;
   }


### PR DESCRIPTION
Thanks for this project. To reduce diff noise, it would be nice if the exports produced by the library didn't arbitrarily move around. This tiny addition simply sorts them before iteration.